### PR TITLE
Settings link fix

### DIFF
--- a/src/components/settingComponents/sidebar.jsx
+++ b/src/components/settingComponents/sidebar.jsx
@@ -11,30 +11,30 @@ export default function Sidebar() {
       <ul className="mr-2 py-2">
         <li className="py-1">
           <Link href="../settings" passHref>
-            <a className="px-2 py-1 text-lg font-medium text-white hover:text-gray-400 sm:text-base">
+            <div className="px-2 py-1 text-lg font-medium text-white hover:text-gray-400 sm:text-base">
               General
-            </a>
+            </div>
           </Link>
         </li>
         <li className="py-1">
           <Link href="../settings/security" passHref>
-            <a className="px-2 py-1 text-lg font-medium text-white hover:text-gray-400 sm:text-base">
+            <div className="px-2 py-1 text-lg font-medium text-white hover:text-gray-400 sm:text-base">
               Security
-            </a>
+            </div>
           </Link>
         </li>
         <li className="py-1">
           <Link href="../settings/preferences" passHref>
-            <a className="px-2 py-1 text-lg font-medium text-white hover:text-gray-400 sm:text-base">
+            <div className="px-2 py-1 text-lg font-medium text-white hover:text-gray-400 sm:text-base">
               Email Preferences
-            </a>
+            </div>
           </Link>
         </li>
         <li className="py-1">
           <Link href="../settings/billing" passHref>
-            <a className="px-2 py-1 text-lg font-medium text-white hover:text-gray-400 sm:text-base">
+            <div className="px-2 py-1 text-lg font-medium text-white hover:text-gray-400 sm:text-base">
               Billing
-            </a>
+            </div>
           </Link>
         </li>
       </ul>


### PR DESCRIPTION
The settings sidebar was using a old < Next.JS 13.x.x way of doing links. <Link><a></a></Link>. Finally found what was causing the issue. It was the sidebar.